### PR TITLE
Add AI skills group to LeftContainer

### DIFF
--- a/src/containers/left-container/LeftContainer.jsx
+++ b/src/containers/left-container/LeftContainer.jsx
@@ -20,6 +20,11 @@ export default function LeftContainer() {
         {label: 'AWS', score: '3'},
     ];
 
+    const ai = [
+        {label: 'Claude Code', score: '3'},
+        {label: 'Codex', score: '3'},
+    ];
+
     const expertise = [
         {label: 'Clean code'},
         {label: 'Micro-services & SaaS'},
@@ -50,6 +55,7 @@ export default function LeftContainer() {
 
             <SkillsGroup title='Programming languages' skills={programmingLanguages}/>
             <SkillsGroup title='Frameworks & Tools' skills={frameworks}/>
+            <SkillsGroup title='AI' skills={ai}/>
             <SkillsGroup title='Expertise' skills={expertise}/>
             <SkillsGroup title='Languages' skills={languages}/>
         </div>


### PR DESCRIPTION
### Motivation
- Expose AI-related tooling proficiency in the resume left column by adding a dedicated AI skills group so those technologies are visible in the UI.

### Description
- Added an `ai` array and rendered it via `SkillsGroup` in `src/containers/left-container/LeftContainer.jsx` by inserting `<SkillsGroup title='AI' skills={ai}/>` into the component.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc97106fc83289d6c8cbe37fa050e)